### PR TITLE
Embedding TTCatalog demo into Overview page

### DIFF
--- a/_pages/home.html
+++ b/_pages/home.html
@@ -81,6 +81,9 @@ ITEM;
 <div class="showcase">
 
 <div <?= fid('overview') ?>>
+<div style="float: right; text-align: right; width: 400px;">
+  <iframe src="http://www.pieceable.com/view/embed/v2/rc/2081d3b43699073b0e8de9ac91e7089480990ad4" scrolling="no"  width="390" height="560" frameborder="0"></iframe>
+</div>
 <h1>Overview</h1>
 <p>
   Three20 is a open source Objective-C library used by dozens of well-known brands in the
@@ -92,6 +95,9 @@ ITEM;
   The library is modular, meaning you choose which elements of the library to include in your
   app. This modular design allows Three20 to be one of the only Objective-C frameworks
   that encourages what are called 'extensions' from the community.
+</p>
+<p>
+  You can explore some features of Three20 using the playable demo on the right. 
 </p>
 </div> <!-- #overview -->
 


### PR DESCRIPTION
Added a playable demo of TTCatalog to the Overview front page.

It looks like this --
http://fpotter_public.s3.amazonaws.com/three20-with-demo.jpg

And, when you hit play on the demo, it starts up this --
http://www.pieceable.com/view/rc/2081d3b43699073b0e8de9ac91e7089480990ad4

Jeff - Please let me know if you think this is best put under Overview or in a separate Web-based Demo section.

Thanks!
