### PR TITLE
Fixed comment referring to app1 when the command references app2.

### DIFF
--- a/_posts/2010-10-06-Adding-Three20-To-Your-Project.mdown
+++ b/_posts/2010-10-06-Adding-Three20-To-Your-Project.mdown
@@ -34,7 +34,7 @@ take advantage of this directory layout.
     
     # Work on app2
     three20 > git checkout app2                     # Check out app2's branch of modifications
-    three20 > open ../projects/app2/app2.xcodeproj  # Open app1 in Xcode
+    three20 > open ../projects/app2/app2.xcodeproj  # Open app2 in Xcode
     
     # Create a new app
     three20 > git checkout -b app3 master           # Create a new branch, 'app3', at master


### PR DESCRIPTION
Very minor issue, but the comment from the first code block appears to have been copied down to the second code block but not updated, so while the code's referring to app2, the comments are referring to app1.
